### PR TITLE
Fixing issues with .dockerignore for *Nix systems

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,16 +11,16 @@
 *.tape
 *.temp
 *.zip
-\debug
+/debug
 *.bk
-\Cheap Hack
+/Cheap Hack
 *.csv
 *.txt
-\datamodeler
-\exp
-\scratch
-\bin
-\logs
+/datamodeler
+/exp
+/scratch
+/bin
+/logs
 join_us.sql
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: perl
 perl:
   - "5.26"
-  - "5.24"
   - "5.10"
 
 before_install:
-  - cpanm Test::Code::TidyAll
-  - cpanm Perl::Critic
-  - cpanm Test::Perl::Critic
-  - cpanm Perl::Tidy
-  - cpanm -n Devel::Cover::Report::Coveralls
+  - cpanm --notest Test::Code::TidyAll
+  - cpanm --notest Perl::Critic
+  - cpanm --notest Test::Perl::Critic
+  - cpanm --notest Perl::Tidy
+  - cpanm --notest Devel::Cover::Report::Coveralls
 script:
   perl Build.PL && ./Build build && cover -test -report coveralls
 


### PR DESCRIPTION
Fixing issues with .dockerignore for *Nix systems

*Nix System like Amazon Linux 2 don't like backslashes in the .dockerignore file as it turns out. It causes docker to throw the following less than helpful error message:

```bash
$ docker build -t 'model-citizen:aws_testing' /home/ec2-user/git/model-citizen/
error checking context: 'syntax error in pattern'.
```
